### PR TITLE
Displays throughput in building descriptions

### DIFF
--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -290,7 +290,7 @@
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
-    <description>An intake fan.</description>
+    <description>An intake fan. Throughput: 300 cc/s.</description>
     <costList>
       <Steel>100</Steel>
       <ComponentIndustrial>1</ComponentIndustrial>
@@ -354,7 +354,7 @@
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
-    <description>A climate control unit for heating and cooling air.</description>
+    <description>A climate control unit for heating and cooling air. Throughput: 900 cc/s.</description>
     <costList>
       <Steel>200</Steel>
       <ComponentIndustrial>3</ComponentIndustrial>
@@ -420,7 +420,7 @@
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
-    <description>A large intake fan.</description>
+    <description>A large intake fan. Throughput: 1500 cc/s.</description>
     <costList>
       <Steel>300</Steel>
       <ComponentIndustrial>3</ComponentIndustrial>
@@ -485,7 +485,7 @@
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
-    <description>A large climate control unit for heating and cooling air.</description>
+    <description>A large climate control unit for heating and cooling air. Throughput: 4500 cc/s.</description>
     <costList>
       <Steel>600</Steel>
       <ComponentIndustrial>9</ComponentIndustrial>

--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Vents.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Vents.xml
@@ -79,7 +79,7 @@
       <Mass>1</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>A small wall-mounted air vent, pushes 50cc of air.</description>
+    <description>A small wall-mounted air vent. Throughput: 50 cc/s.</description>
     <costList>
       <Steel>35</Steel>
     </costList>
@@ -117,7 +117,7 @@
       <Mass>2</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>A wall-mounted air vent, pushes 100cc of air.</description>
+    <description>A wall-mounted air vent. Throughput: 100 cc/s.</description>
     <costList>
       <Steel>70</Steel>
     </costList>
@@ -155,7 +155,7 @@
       <Mass>50</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>A surround exhaust vent, pushes 300cc of air.</description>
+    <description>A surround exhaust vent. Throughput: 300 cc/s.</description>
     <costList>
       <Steel>210</Steel>
     </costList>
@@ -195,7 +195,7 @@
       <Mass>100</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>A large surround exhaust vent, pushes 600cc of air.</description>
+    <description>A large surround exhaust vent. Throughput: 600 cc/s.</description>
     <costList>
       <Steel>420</Steel>
     </costList>


### PR DESCRIPTION
This PR simply adds the throughput in building descriptions of the 1.3 version, so people do not have to look for and to remember them from the online tutorial.